### PR TITLE
Fix: CFn: mappings with references

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/errors.py
+++ b/localstack-core/localstack/services/cloudformation/engine/errors.py
@@ -1,0 +1,4 @@
+class TemplateError(RuntimeError):
+    """
+    Error thrown on a programming error from the user
+    """

--- a/localstack-core/localstack/services/cloudformation/resource_provider.py
+++ b/localstack-core/localstack/services/cloudformation/resource_provider.py
@@ -477,6 +477,7 @@ class ResourceProviderExecutor:
                     context = {**payload["callbackContext"], **event.custom_context}
                     payload["callbackContext"] = context
                     payload["requestData"]["resourceProperties"] = event.resource_model
+                    resource["Properties"] = event.resource_model
 
                     if current_iteration == 0:
                         time.sleep(0)

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.snapshot.json
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.snapshot.json
@@ -63,5 +63,21 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_deletion_of_failed_nested_stack": {
+    "recorded-date": "17-09-2024, 20:09:36",
+    "recorded-content": {
+      "error": {
+        "Error": {
+          "Code": "ValidationError",
+          "Message": "Stack with id <nested-stack-name> does not exist",
+          "Type": "Sender"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 400
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
+++ b/tests/aws/services/cloudformation/api/test_nested_stacks.validation.json
@@ -1,4 +1,7 @@
 {
+  "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_deletion_of_failed_nested_stack": {
+    "last_validated_date": "2024-09-17T20:09:36+00:00"
+  },
   "tests/aws/services/cloudformation/api/test_nested_stacks.py::test_nested_output_in_params": {
     "last_validated_date": "2023-02-07T09:57:47+00:00"
   }

--- a/tests/aws/services/cloudformation/engine/test_mappings.py
+++ b/tests/aws/services/cloudformation/engine/test_mappings.py
@@ -153,3 +153,23 @@ class TestCloudFormationMappings:
                 ],
             )
         snapshot.match("mapping_minimum_level_exc", e.value.response)
+
+    @markers.aws.validated
+    def test_mapping_ref_map_key(self, deploy_cfn_template, aws_client, snapshot):
+        topic_name = f"topic-{short_uid()}"
+        stack = deploy_cfn_template(
+            template_path=os.path.join(
+                THIS_DIR, "../../../templates/mappings/mapping-ref-map-key.yaml"
+            ),
+            parameters={
+                "MapName": "MyMap",
+                "MapKey": "A",
+                "TopicName": topic_name,
+            },
+        )
+
+        topic_arn = stack.outputs.get("TopicArn")
+        assert topic_arn is not None
+
+        describe_res = aws_client.sns.get_topic_attributes(TopicArn=topic_arn)
+        snapshot.match("topic-attributes", describe_res)

--- a/tests/aws/services/cloudformation/engine/test_mappings.snapshot.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.snapshot.json
@@ -62,5 +62,70 @@
         }
       }
     }
+  },
+  "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_ref_map_key": {
+    "recorded-date": "18-09-2024, 21:26:20",
+    "recorded-content": {
+      "topic-attributes": {
+        "Attributes": {
+          "DisplayName": "",
+          "EffectiveDeliveryPolicy": {
+            "http": {
+              "defaultHealthyRetryPolicy": {
+                "minDelayTarget": 20,
+                "maxDelayTarget": 20,
+                "numRetries": 3,
+                "numMaxDelayRetries": 0,
+                "numNoDelayRetries": 0,
+                "numMinDelayRetries": 0,
+                "backoffFunction": "linear"
+              },
+              "disableSubscriptionOverrides": false,
+              "defaultRequestPolicy": {
+                "headerContentType": "text/plain; charset=UTF-8"
+              }
+            }
+          },
+          "Owner": "111111111111",
+          "Policy": {
+            "Version": "2008-10-17",
+            "Id": "__default_policy_ID",
+            "Statement": [
+              {
+                "Sid": "__default_statement_ID",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "*"
+                },
+                "Action": [
+                  "SNS:GetTopicAttributes",
+                  "SNS:SetTopicAttributes",
+                  "SNS:AddPermission",
+                  "SNS:RemovePermission",
+                  "SNS:DeleteTopic",
+                  "SNS:Subscribe",
+                  "SNS:ListSubscriptionsByTopic",
+                  "SNS:Publish"
+                ],
+                "Resource": "arn:<partition>:sns:<region>:111111111111:topic-f1301a86",
+                "Condition": {
+                  "StringEquals": {
+                    "AWS:SourceOwner": "111111111111"
+                  }
+                }
+              }
+            ]
+          },
+          "SubscriptionsConfirmed": "0",
+          "SubscriptionsDeleted": "0",
+          "SubscriptionsPending": "0",
+          "TopicArn": "arn:<partition>:sns:<region>:111111111111:topic-f1301a86"
+        },
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      }
+    }
   }
 }

--- a/tests/aws/services/cloudformation/engine/test_mappings.validation.json
+++ b/tests/aws/services/cloudformation/engine/test_mappings.validation.json
@@ -5,6 +5,9 @@
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_minimum_nesting_depth": {
     "last_validated_date": "2023-06-12T14:47:25+00:00"
   },
+  "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_ref_map_key": {
+    "last_validated_date": "2024-09-18T21:26:20+00:00"
+  },
   "tests/aws/services/cloudformation/engine/test_mappings.py::TestCloudFormationMappings::test_mapping_with_invalid_refs": {
     "last_validated_date": "2023-06-12T14:47:24+00:00"
   },

--- a/tests/aws/templates/cfn_failed_nested_stack_child.yml
+++ b/tests/aws/templates/cfn_failed_nested_stack_child.yml
@@ -1,0 +1,34 @@
+Resources:
+  MyLambdaFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: testFunction
+      Handler: index.handler
+      Runtime: python3.8
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        S3Bucket: non-existent-bucket-name  # Invalid S3 bucket that does not exist
+        S3Key: non-existent-key.zip
+
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: LambdaExecutionRole
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaBasicExecution
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*

--- a/tests/aws/templates/cfn_failed_nested_stack_parent.yml
+++ b/tests/aws/templates/cfn_failed_nested_stack_parent.yml
@@ -1,0 +1,14 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  TemplateUri:
+    Type: String
+
+Resources:
+  ChildStack:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Ref TemplateUri
+
+Outputs:
+  BucketStackId:
+    Value: !Ref ChildStack

--- a/tests/aws/templates/mappings/mapping-ref-map-key.yaml
+++ b/tests/aws/templates/mappings/mapping-ref-map-key.yaml
@@ -1,0 +1,36 @@
+Mappings:
+  MyMap:
+    A:
+      value: "true"
+    C:
+      value: "false"
+
+Conditions:
+  MyCondition: !Equals
+    - !FindInMap [ !Ref MapName, !Ref MapKey, value ]
+    - "true"
+
+Parameters:
+  MapName:
+    Type: String
+
+  MapKey:
+    Type: String
+
+  TopicName:
+    Type: String
+
+Resources:
+  MyTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Ref TopicName
+    Condition: MyCondition
+
+  Dummy:
+    Type: AWS::SNS::Topic
+
+Outputs:
+  TopicArn:
+    Value: !Ref MyTopic
+


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
A customer presented an error which involved a `FindInMap` in a `Condition`. The `FindInMap` uses `Refs` for its map and top level keys, which raised an error:

```
    return mappings[map_name][top_level_key][second_level_key]
           ~~~~~~~~^^^^^^^^^^
TypeError: unhashable type: 'dict'
```

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Implement the fix by resolving the ref from the template parameters
* Improve error handling on invalid input

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
