### PR TITLE
Add JRE dependency to Java components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# base: Stage which installs necessary runtime dependencies (OS packages, java,...)
+# base: Stage which installs necessary runtime dependencies (OS packages, etc.)
 #
 FROM python:3.11.10-slim-bookworm@sha256:50ec89bdac0a845ec1751f91cb6187a3d8adb2b919d6e82d17acf48d1a9743fc AS base
 ARG TARGETARCH
@@ -89,7 +89,6 @@ ADD bin/hosts /etc/hosts
 # expose default environment
 # Set edge bind host so localstack can be reached by other containers
 # set library path and default LocalStack hostname
-ENV LD_LIBRARY_PATH=$JAVA_HOME/lib:$JAVA_HOME/lib/server
 ENV USER=localstack
 ENV PYTHONUNBUFFERED=1
 
@@ -155,17 +154,11 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION_FOR_LOCALSTACK_CORE=${LOCALSTACK_BUILD_VERSIO
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/var/lib/localstack/cache \
     source .venv/bin/activate && \
-    python -m localstack.cli.lpm install java --version 11 && \
     python -m localstack.cli.lpm install \
       lambda-runtime \
       dynamodb-local && \
     chown -R localstack:localstack /usr/lib/localstack && \
     chmod -R 777 /usr/lib/localstack
-
-# Set up Java
-ENV JAVA_HOME /usr/lib/localstack/java/11
-RUN ln -s $JAVA_HOME/bin/java /usr/bin/java
-ENV PATH="${PATH}:${JAVA_HOME}/bin"
 
 # link the python package installer virtual environments into the localstack venv
 RUN echo /var/lib/localstack/lib/python-packages/lib/python3.11/site-packages > localstack-var-python-packages-venv.pth && \

--- a/localstack-core/localstack/services/dynamodb/packages.py
+++ b/localstack-core/localstack/services/dynamodb/packages.py
@@ -41,6 +41,13 @@ class DynamoDBLocalPackageInstaller(PackageInstaller):
     def __init__(self):
         super().__init__("dynamodb-local", "latest")
 
+        self.java_version = "11"
+
+    def _prepare_installation(self, target: InstallTarget) -> None:
+        from localstack.packages.java import java_package
+
+        java_package.get_installer(self.java_version).install()
+
     def _install(self, target: InstallTarget):
         # download and extract archive
         tmp_archive = os.path.join(config.dirs.cache, "localstack.ddb.zip")

--- a/localstack-core/localstack/services/dynamodb/packages.py
+++ b/localstack-core/localstack/services/dynamodb/packages.py
@@ -45,7 +45,7 @@ class DynamoDBLocalPackageInstaller(PackageInstaller):
         self.java_version = "11"
 
     def _prepare_installation(self, target: InstallTarget) -> None:
-        java_package.get_installer(self.java_version).install()
+        java_package.get_installer(self.java_version).install(target)
 
     def _install(self, target: InstallTarget):
         # download and extract archive

--- a/localstack-core/localstack/services/dynamodb/packages.py
+++ b/localstack-core/localstack/services/dynamodb/packages.py
@@ -4,6 +4,7 @@ from typing import List
 from localstack import config
 from localstack.constants import ARTIFACTS_REPO, MAVEN_REPO_URL
 from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.packages.java import java_package
 from localstack.utils.archives import (
     download_and_extract_with_retry,
     update_jar_manifest,
@@ -44,8 +45,6 @@ class DynamoDBLocalPackageInstaller(PackageInstaller):
         self.java_version = "11"
 
     def _prepare_installation(self, target: InstallTarget) -> None:
-        from localstack.packages.java import java_package
-
         java_package.get_installer(self.java_version).install()
 
     def _install(self, target: InstallTarget):

--- a/localstack-core/localstack/services/events/event_ruler.py
+++ b/localstack-core/localstack/services/events/event_ruler.py
@@ -2,7 +2,9 @@ import logging
 import os
 from functools import cache
 from pathlib import Path
+from typing import Tuple
 
+from localstack.packages.java import java_package
 from localstack.services.events.models import InvalidEventPatternException
 from localstack.services.events.packages import event_ruler_package
 from localstack.utils.objects import singleton_factory
@@ -25,16 +27,26 @@ def start_jvm() -> None:
     jpype_config.destroy_jvm = False
 
     if not jpype.isJVMStarted():
-        event_ruler_libs_path = get_event_ruler_libs_path()
+        jvm_lib, event_ruler_libs_path = get_jpype_lib_paths()
         event_ruler_libs_pattern = event_ruler_libs_path.joinpath("*")
-        jpype.startJVM(classpath=[event_ruler_libs_pattern])
+
+        jpype.startJVM(jvm_lib, classpath=[event_ruler_libs_pattern])
 
 
 @cache
-def get_event_ruler_libs_path() -> Path:
+def get_jpype_lib_paths() -> Tuple[Path, Path]:
+    """
+    Downloads Event Ruler, its dependencies and returns a tuple of:
+    - Path to libjvm.so to be used by JPype as jvmpath
+    - Path to Event Ruler libraries to be used by JPype as classpath
+    """
     installer = event_ruler_package.get_installer()
     installer.install()
-    return Path(installer.get_installed_dir())
+
+    java_home = java_package.get_installer(installer.java_version).get_java_home()
+    jvm_lib = Path(java_home) / "lib" / "server" / "libjvm.so"
+
+    return jvm_lib, Path(installer.get_installed_dir())
 
 
 def matches_rule(event: str, rule: str) -> bool:

--- a/localstack-core/localstack/services/events/event_ruler.py
+++ b/localstack-core/localstack/services/events/event_ruler.py
@@ -30,7 +30,7 @@ def start_jvm() -> None:
         jvm_lib, event_ruler_libs_path = get_jpype_lib_paths()
         event_ruler_libs_pattern = event_ruler_libs_path.joinpath("*")
 
-        jpype.startJVM(jvm_lib, classpath=[event_ruler_libs_pattern])
+        jpype.startJVM(str(jvm_lib), classpath=[event_ruler_libs_pattern])
 
 
 @cache

--- a/localstack-core/localstack/services/events/packages.py
+++ b/localstack-core/localstack/services/events/packages.py
@@ -1,5 +1,6 @@
 from localstack.packages import InstallTarget, Package, PackageInstaller
 from localstack.packages.core import MavenPackageInstaller
+from localstack.packages.java import java_package
 
 # https://central.sonatype.com/artifact/software.amazon.event.ruler/event-ruler
 EVENT_RULER_VERSION = "1.7.3"
@@ -30,8 +31,6 @@ class EventRulerPackageInstaller(MavenPackageInstaller):
         self.java_version = "11"
 
     def _prepare_installation(self, target: InstallTarget) -> None:
-        from localstack.packages.java import java_package
-
         java_package.get_installer(self.java_version).install()
 
 

--- a/localstack-core/localstack/services/events/packages.py
+++ b/localstack-core/localstack/services/events/packages.py
@@ -31,7 +31,7 @@ class EventRulerPackageInstaller(MavenPackageInstaller):
         self.java_version = "11"
 
     def _prepare_installation(self, target: InstallTarget) -> None:
-        java_package.get_installer(self.java_version).install()
+        java_package.get_installer(self.java_version).install(target)
 
 
 event_ruler_package = EventRulerPackage()

--- a/localstack-core/localstack/services/events/packages.py
+++ b/localstack-core/localstack/services/events/packages.py
@@ -1,4 +1,4 @@
-from localstack.packages import Package, PackageInstaller
+from localstack.packages import InstallTarget, Package, PackageInstaller
 from localstack.packages.core import MavenPackageInstaller
 
 # https://central.sonatype.com/artifact/software.amazon.event.ruler/event-ruler
@@ -15,12 +15,24 @@ class EventRulerPackage(Package):
         return [EVENT_RULER_VERSION]
 
     def _get_installer(self, version: str) -> PackageInstaller:
-        return MavenPackageInstaller(
+        return EventRulerPackageInstaller()
+
+
+class EventRulerPackageInstaller(MavenPackageInstaller):
+    def __init__(self):
+        super().__init__(
             f"pkg:maven/software.amazon.event.ruler/event-ruler@{EVENT_RULER_VERSION}",
             f"pkg:maven/com.fasterxml.jackson.core/jackson-annotations@{JACKSON_VERSION}",
             f"pkg:maven/com.fasterxml.jackson.core/jackson-core@{JACKSON_VERSION}",
             f"pkg:maven/com.fasterxml.jackson.core/jackson-databind@{JACKSON_VERSION}",
         )
+
+        self.java_version = "11"
+
+    def _prepare_installation(self, target: InstallTarget) -> None:
+        from localstack.packages.java import java_package
+
+        java_package.get_installer(self.java_version).install()
 
 
 event_ruler_package = EventRulerPackage()

--- a/localstack-core/localstack/services/opensearch/cluster.py
+++ b/localstack-core/localstack/services/opensearch/cluster.py
@@ -16,6 +16,7 @@ from localstack.aws.api.opensearch import (
 )
 from localstack.http.client import SimpleRequestsClient
 from localstack.http.proxy import ProxyHandler
+from localstack.packages.java import java_package
 from localstack.services.edge import ROUTER
 from localstack.services.opensearch import versions
 from localstack.services.opensearch.packages import elasticsearch_package, opensearch_package
@@ -465,7 +466,10 @@ class OpensearchCluster(Server):
         return cmd
 
     def _create_env_vars(self, directories: Directories) -> Dict:
+        elasticsearch_installer = elasticsearch_package.get_installer(self.version)
+        java_home = java_package.get_installer(elasticsearch_installer.java_version).get_java_home()
         env_vars = {
+            "JAVA_HOME": java_home,
             "OPENSEARCH_JAVA_OPTS": os.environ.get("OPENSEARCH_JAVA_OPTS", "-Xms200m -Xmx600m"),
             "OPENSEARCH_TMPDIR": directories.tmp,
         }
@@ -688,7 +692,10 @@ class ElasticsearchCluster(OpensearchCluster):
         return settings
 
     def _create_env_vars(self, directories: Directories) -> Dict:
+        opensearch_installer = opensearch_package.get_installer(self.version)
+        java_home = java_package.get_installer(opensearch_installer.java_version).get_java_home()
         return {
+            "JAVA_HOME": java_home,
             "ES_JAVA_OPTS": os.environ.get("ES_JAVA_OPTS", "-Xms200m -Xmx600m"),
             "ES_TMPDIR": directories.tmp,
         }

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -49,6 +49,17 @@ class OpensearchPackageInstaller(PackageInstaller):
     def __init__(self, version: str):
         super().__init__("opensearch", version)
 
+        # JRE version to use
+        # OpenSearch has the widest compatibility with Java 11
+        # See: https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/#java-compatibility
+        self.java_version = "11"
+
+    def _prepare_installation(self, target: InstallTarget) -> None:
+        from localstack.packages.java import java_package
+
+        # OpenSearch ships with a bundled JRE, but we still use LocalStack's JRE for predictability
+        java_package.get_installer(self.java_version).install()
+
     def _install(self, target: InstallTarget):
         # locally import to avoid having a dependency on ASF when starting the CLI
         from localstack.aws.api.opensearch import EngineType
@@ -215,6 +226,17 @@ class OpensearchPackageInstaller(PackageInstaller):
 class ElasticsearchPackageInstaller(PackageInstaller):
     def __init__(self, version: str):
         super().__init__("elasticsearch", version)
+
+        # JRE version to use
+        # ElasticSearch has the widest compatibility with Java 8
+        # See: https://www.elastic.co/support/matrix
+        self.java_version = "8"
+
+    def _prepare_installation(self, target: InstallTarget) -> None:
+        from localstack.packages.java import java_package
+
+        # ElasticSearch ships with a bundled JRE, but we still use LocalStack's JRE for predictability
+        java_package.get_installer(self.java_version).install()
 
     def _install(self, target: InstallTarget):
         # locally import to avoid having a dependency on ASF when starting the CLI

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -57,7 +57,7 @@ class OpensearchPackageInstaller(PackageInstaller):
 
     def _prepare_installation(self, target: InstallTarget) -> None:
         # OpenSearch ships with a bundled JRE, but we still use LocalStack's JRE for predictability
-        java_package.get_installer(self.java_version).install()
+        java_package.get_installer(self.java_version).install(target)
 
     def _install(self, target: InstallTarget):
         # locally import to avoid having a dependency on ASF when starting the CLI
@@ -233,7 +233,7 @@ class ElasticsearchPackageInstaller(PackageInstaller):
 
     def _prepare_installation(self, target: InstallTarget) -> None:
         # ElasticSearch ships with a bundled JRE, but we still use LocalStack's JRE for predictability
-        java_package.get_installer(self.java_version).install()
+        java_package.get_installer(self.java_version).install(target)
 
     def _install(self, target: InstallTarget):
         # locally import to avoid having a dependency on ASF when starting the CLI

--- a/localstack-core/localstack/services/opensearch/packages.py
+++ b/localstack-core/localstack/services/opensearch/packages.py
@@ -18,6 +18,7 @@ from localstack.constants import (
     OPENSEARCH_PLUGIN_LIST,
 )
 from localstack.packages import InstallTarget, Package, PackageInstaller
+from localstack.packages.java import java_package
 from localstack.services.opensearch import versions
 from localstack.utils.archives import download_and_extract_with_retry
 from localstack.utils.files import chmod_r, load_file, mkdir, rm_rf, save_file
@@ -55,8 +56,6 @@ class OpensearchPackageInstaller(PackageInstaller):
         self.java_version = "11"
 
     def _prepare_installation(self, target: InstallTarget) -> None:
-        from localstack.packages.java import java_package
-
         # OpenSearch ships with a bundled JRE, but we still use LocalStack's JRE for predictability
         java_package.get_installer(self.java_version).install()
 
@@ -233,8 +232,6 @@ class ElasticsearchPackageInstaller(PackageInstaller):
         self.java_version = "8"
 
     def _prepare_installation(self, target: InstallTarget) -> None:
-        from localstack.packages.java import java_package
-
         # ElasticSearch ships with a bundled JRE, but we still use LocalStack's JRE for predictability
         java_package.get_installer(self.java_version).install()
 

--- a/localstack-core/localstack/services/stepfunctions/legacy/stepfunctions_starter.py
+++ b/localstack-core/localstack/services/stepfunctions/legacy/stepfunctions_starter.py
@@ -1,9 +1,11 @@
 import logging
+import os
 import threading
 from typing import Any, Dict
 
 from localstack import config
-from localstack.services.stepfunctions.packages import stepfunctions_local_package
+from localstack.packages.java import java_package
+from localstack.services.stepfunctions.packages import SFN_JAVA_VERSION, stepfunctions_local_package
 from localstack.utils.aws import aws_stack
 from localstack.utils.net import get_free_tcp_port, port_can_be_bound
 from localstack.utils.run import ShellCommandThread
@@ -42,11 +44,17 @@ class StepFunctionsServer(Server):
         return t
 
     def generate_env_vars(self) -> Dict[str, Any]:
+        java_home = java_package.get_installer(SFN_JAVA_VERSION).get_java_home()
+
+        path = f"{java_home}/bin:{os.getenv('PATH')}"
+
         return {
             "EDGE_PORT": config.GATEWAY_LISTEN[0].port,
             "EDGE_PORT_HTTP": config.GATEWAY_LISTEN[0].port,
             "DATA_DIR": config.dirs.data,
+            "JAVA_HOME": java_home,
             "PORT": self._port,
+            "PATH": path,
         }
 
     def generate_shell_command(self) -> str:

--- a/localstack-core/localstack/services/stepfunctions/packages.py
+++ b/localstack-core/localstack/services/stepfunctions/packages.py
@@ -81,7 +81,7 @@ class StepFunctionsLocalPackageInstaller(ExecutableInstaller):
         return os.path.join(install_dir, "StepFunctionsLocal.jar")
 
     def _prepare_installation(self, target: InstallTarget) -> None:
-        java_package.get_installer(SFN_JAVA_VERSION).install()
+        java_package.get_installer(SFN_JAVA_VERSION).install(target)
 
     def _install(self, target: InstallTarget) -> None:
         """

--- a/localstack-core/localstack/services/stepfunctions/packages.py
+++ b/localstack-core/localstack/services/stepfunctions/packages.py
@@ -9,6 +9,7 @@ import requests
 from localstack.constants import ARTIFACTS_REPO, MAVEN_REPO_URL
 from localstack.packages import InstallTarget, Package, PackageInstaller
 from localstack.packages.core import ExecutableInstaller
+from localstack.packages.java import java_package
 from localstack.utils.archives import add_file_to_jar, untar, update_jar_manifest
 from localstack.utils.files import file_exists_not_empty, mkdir, new_tmp_file, rm_rf
 from localstack.utils.http import download
@@ -17,6 +18,8 @@ from localstack.utils.http import download
 URL_ASPECTJRT = f"{MAVEN_REPO_URL}/org/aspectj/aspectjrt/1.9.7/aspectjrt-1.9.7.jar"
 URL_ASPECTJWEAVER = f"{MAVEN_REPO_URL}/org/aspectj/aspectjweaver/1.9.7/aspectjweaver-1.9.7.jar"
 JAR_URLS = [URL_ASPECTJRT, URL_ASPECTJWEAVER]
+
+SFN_JAVA_VERSION = "11"
 
 SFN_PATCH_URL_PREFIX = (
     f"{ARTIFACTS_REPO}/raw/ac84739adc87ff4b5553478f6849134bcd259672/stepfunctions-local-patch"
@@ -76,6 +79,9 @@ class StepFunctionsLocalPackage(Package):
 class StepFunctionsLocalPackageInstaller(ExecutableInstaller):
     def _get_install_marker_path(self, install_dir: str) -> str:
         return os.path.join(install_dir, "StepFunctionsLocal.jar")
+
+    def _prepare_installation(self, target: InstallTarget) -> None:
+        java_package.get_installer(SFN_JAVA_VERSION).install()
 
     def _install(self, target: InstallTarget) -> None:
         """


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Background
https://github.com/localstack/localstack/pull/11139 introduced a Java LPM package that can install and manage multiple LTS versions of JRE.

This PR integrates this package across the codebase.


<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* The default system-wide JRE that was previously installed during Docker build is removed
* Instead, each component has an explicit dependency on the Java package, and is responsible for installing the required version
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
