### PR TITLE
WIP: Introduce experimental JSON logging

### DIFF
--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -1,4 +1,3 @@
-
 from localstack import config
 from localstack.aws import handlers
 from localstack.aws.api import RequestContext
@@ -29,6 +28,7 @@ class LocalstackAwsGateway(Gateway):
         # the main request handler chain
         self.request_handlers.extend(
             [
+                handlers.log_request,
                 handlers.push_request_context,
                 handlers.add_internal_request_params,
                 handlers.handle_runtime_shutdown,

--- a/localstack/aws/app.py
+++ b/localstack/aws/app.py
@@ -1,3 +1,4 @@
+
 from localstack import config
 from localstack.aws import handlers
 from localstack.aws.api import RequestContext
@@ -45,6 +46,7 @@ class LocalstackAwsGateway(Gateway):
                 handlers.add_region_from_header,
                 handlers.add_account_id,
                 handlers.parse_service_request,
+                # TODO: add logger that initializes a request "trace"
                 metric_collector.record_parsed_request,
                 handlers.serve_custom_service_request_handlers,
                 load_service,  # once we have the service request we can make sure we load the service

--- a/localstack/aws/handlers/__init__.py
+++ b/localstack/aws/handlers/__init__.py
@@ -45,3 +45,4 @@ serve_edge_router_rules = legacy.EdgeRouterHandler()
 set_close_connection_header = legacy.set_close_connection_header
 push_request_context = legacy.push_request_context
 pop_request_context = legacy.pop_request_context
+log_request = logging.RequestLogger()

--- a/localstack/aws/handlers/logging.py
+++ b/localstack/aws/handlers/logging.py
@@ -72,11 +72,12 @@ class ResponseLogger:
 
     # make sure loggers are loaded after logging config is loaded
     def _prepare_logger(self, logger: logging.Logger, formatter: Type):
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.propagate = False
-            handler = create_default_handler(logger.level)
-            handler.setFormatter(formatter())
-            logger.addHandler(handler)
+        # TODO: uncommenting this will block .http and .aws logs from being propagated
+        # if logger.isEnabledFor(logging.DEBUG):
+        #     logger.propagate = False
+        #     handler = create_default_handler(logger.level)
+        #     handler.setFormatter(formatter())
+        #     logger.addHandler(handler)
         return logger
 
     def _log(self, context: RequestContext, response: Response):
@@ -95,6 +96,10 @@ class ResponseLogger:
                     response.status_code,
                     context.service_exception.code,
                     extra={
+                        "request_id": context.request_id,
+                        "service": context.service.service_name,
+                        "operation": context.operation.name,
+                        "status_code": response.status_code,
                         # context
                         "account_id": context.account_id,
                         "region": context.region,
@@ -117,6 +122,10 @@ class ResponseLogger:
                     context.operation.name,
                     response.status_code,
                     extra={
+                        "request_id": context.request_id,
+                        "service": context.service.service_name,
+                        "operation": context.operation.name,
+                        "status_code": response.status_code,
                         # context
                         "account_id": context.account_id,
                         "region": context.region,
@@ -142,6 +151,9 @@ class ResponseLogger:
                 context.request.path,
                 response.status_code,
                 extra={
+                    "request_id": context.request_id or "NOREQUESTID",
+                    "http_method": context.request.method,
+                    "status_code": response.status_code,
                     # request
                     "input_type": "Request",
                     "input": restore_payload(context.request),

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -3,8 +3,9 @@ import logging
 import sys
 import warnings
 
-from localstack import config, constants
 from localstack_snapshot.util.encoding import CustomJsonEncoder
+
+from localstack import config, constants
 
 from .format import AddFormattedAttributes, DefaultFormatter
 
@@ -88,6 +89,7 @@ def create_default_handler(log_level: int):
     log_handler.addFilter(AddFormattedAttributes())
     return log_handler
 
+
 class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         # TODO: extras are currently flat at root level and not nested
@@ -114,7 +116,6 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(data, cls=CustomJsonEncoder)
 
 
-
 def setup_logging(log_level=logging.INFO) -> None:
     """
     Configures the python logging environment for LocalStack.
@@ -137,28 +138,19 @@ def setup_logging(log_level=logging.INFO) -> None:
     for logger, level in default_log_levels.items():
         logging.getLogger(logger).setLevel(level)
 
+    # Configure JSON logs
+    # TODO: make configurable/opt-in
     logging.basicConfig(level=logging.DEBUG)
     file_handler = logging.FileHandler("/tmp/localstack.log", mode="w", encoding="utf-8")
 
     file_handler.setFormatter(JsonFormatter())
     logging.root.addHandler(file_handler)
-    logging.root.setLevel(logging.DEBUG)
-
-    # loki_handler = LokiHandler()
-    # loki_handler.setLevel(logging.DEBUG)
-    # logging.root.addHandler(loki_handler)
+    logging.root.setLevel(logging.DEBUG)  # FIXME
 
     # silence noisy libs by default
     logging.getLogger("werkzeug").setLevel(logging.CRITICAL)
     logging.getLogger("stevedore").setLevel(logging.CRITICAL)
     logging.getLogger("botocore").setLevel(logging.CRITICAL)
-    # aws_logger = logging.getLogger("localstack.request.aws")
-    # http_logger = logging.getLogger("localstack.request.http")
-    # logging.getLogger("localstack.request.http").setLevel(logging.DEBUG)
-    # logging.getLogger("localstack.request.http").addHandler(file_handler)
-
-    # logging.getLogger("localstack.request.aws").addHandler(file_handler)
-    # logging.getLogger("localstack.request.aws").addHandler(loki_handler)
 
 
 def setup_hypercorn_logger(hypercorn_config) -> None:

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -719,7 +719,6 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         context: RequestContext,
         request: CreateFunctionRequest,
     ) -> FunctionConfiguration:
-        LOG.warning("Function being created", extra={"function_name": request['FunctionName'], "customthing": {"names": "joeldominik"}})
         zip_file = request.get("Code", {}).get("ZipFile")
         if zip_file and len(zip_file) > config.LAMBDA_LIMITS_CODE_SIZE_ZIPPED:
             raise RequestEntityTooLargeException(

--- a/localstack/services/lambda_/provider.py
+++ b/localstack/services/lambda_/provider.py
@@ -719,6 +719,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
         context: RequestContext,
         request: CreateFunctionRequest,
     ) -> FunctionConfiguration:
+        LOG.warning("Function being created", extra={"function_name": request['FunctionName'], "customthing": {"names": "joeldominik"}})
         zip_file = request.get("Code", {}).get("ZipFile")
         if zip_file and len(zip_file) > config.LAMBDA_LIMITS_CODE_SIZE_ZIPPED:
             raise RequestEntityTooLargeException(
@@ -765,6 +766,7 @@ class LambdaProvider(LambdaApi, ServiceLifecycleHook):
                 f"Value {request.get('Runtime')} at 'runtime' failed to satisfy constraint: Member must satisfy enum value set: {VALID_RUNTIMES} or be a valid ARN",
                 Type="User",
             )
+
         request_function_name = request["FunctionName"]
         # Validate FunctionName:
         # a) Function name: just function name (max 64 chars)

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -441,6 +441,7 @@ class TestLambdaBehavior:
             timeout=9,
             Architectures=[Architecture.x86_64],
         )
+        # logging.getLogger("localstack.request.http").debug("?jsds2024")
 
         invoke_result = aws_client.lambda_.invoke(FunctionName=func_name)
         snapshot.match("invoke_runtime_x86_introspection", invoke_result)

--- a/tests/aws/services/lambda_/test_lambda.py
+++ b/tests/aws/services/lambda_/test_lambda.py
@@ -441,7 +441,6 @@ class TestLambdaBehavior:
             timeout=9,
             Architectures=[Architecture.x86_64],
         )
-        # logging.getLogger("localstack.request.http").debug("?jsds2024")
 
         invoke_result = aws_client.lambda_.invoke(FunctionName=func_name)
         snapshot.match("invoke_runtime_x86_introspection", invoke_result)


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
We've had a few requests in the past for outputting our logs in a structured format. We've been experimenting in the past but would like to push forward with the idea now. This will be in an experimental stage for some time now and will mostly be used internally before going into public preview and ideally GA release with 4.0 🤞

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Logs can now also be streamed to a file in JSON format. This is done in a quite naive way right now, we simply take the current log records, and translate it into a JSON dict which then ends up being streamed as newline-delimited JSON where each line corresponds to one log entry.
* The current CLI output is generally not affected by this (except by the addition of the raw request logger)

<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->

## TODO

What's left to do:

- [ ]  Clean up the code from the initial spike
- [ ]   Make this opt-in
- [ ]  Make log sink configurable
- [ ]  Map keys extracted from the LogRecord to more suitable names
- [ ]   Investigate the DEBUG-related code we had to comment out for the aws request/response logging


There will also be some follow ups such as:

* Add an internal endpoint to stream logs from (e.g. via websocket)
* Introduce a proper structured logging strategy and rework log levels
* ... lots more to come in the next few months
