### PR TITLE
Add trace logging for the DNS server

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -418,6 +418,7 @@ if TMP_FOLDER.startswith("/var/folders/") and os.path.exists("/private%s" % TMP_
 LS_LOG = eval_log_type("LS_LOG")
 DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
 
+# EXPERIMENTAL
 # allow setting custom log levels for individual loggers
 LOGGING_OVERRIDE = os.environ.get("LOGGING_OVERRIDE", "")
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -418,6 +418,9 @@ if TMP_FOLDER.startswith("/var/folders/") and os.path.exists("/private%s" % TMP_
 LS_LOG = eval_log_type("LS_LOG")
 DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
 
+# allow setting custom log levels for individual loggers
+LOGGING_OVERRIDE = os.environ.get("LOGGING_OVERRIDE", "{}")
+
 # whether to enable debugpy
 DEVELOP = is_env_true("DEVELOP")
 

--- a/localstack/config.py
+++ b/localstack/config.py
@@ -419,7 +419,7 @@ LS_LOG = eval_log_type("LS_LOG")
 DEBUG = is_env_true("DEBUG") or LS_LOG in TRACE_LOG_LEVELS
 
 # allow setting custom log levels for individual loggers
-LOGGING_OVERRIDE = os.environ.get("LOGGING_OVERRIDE", "{}")
+LOGGING_OVERRIDE = os.environ.get("LOGGING_OVERRIDE", "")
 
 # whether to enable debugpy
 DEVELOP = is_env_true("DEVELOP")

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -94,7 +94,7 @@ def setup_logging_from_config():
             raise
         except Exception as e:
             raise RuntimeError(
-                f"Failed to configure logging overrides ({raw_logging_override}): Malformed value. ({e})"
+                f"Failed to configure logging overrides ({raw_logging_override})"
             ) from e
 
 

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -79,21 +79,22 @@ def setup_logging_from_config():
         for name, level in trace_internal_log_levels.items():
             logging.getLogger(name).setLevel(level)
 
-    if raw_value := config.LOGGING_OVERRIDE:
+    raw_logging_override = config.LOGGING_OVERRIDE
+    if raw_logging_override:
         try:
-            logging_overrides = json.loads(raw_value)
+            logging_overrides = json.loads(raw_logging_override)
             for logger, level_name in logging_overrides.items():
                 level = getattr(logging, level_name, None)
                 if not level:
                     raise RuntimeError(
-                        f"Failed to configure logging overrides ({raw_value}): '{level_name}' is not a valid log level"
+                        f"Failed to configure logging overrides ({raw_logging_override}): '{level_name}' is not a valid log level"
                     )
                 logging.getLogger(logger).setLevel(level)
         except RuntimeError:
             raise
         except Exception as e:
             raise RuntimeError(
-                f"Failed to configure logging overrides ({raw_value}): Malformed value. ({e})"
+                f"Failed to configure logging overrides ({raw_logging_override}): Malformed value. ({e})"
             ) from e
 
 

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -1,10 +1,10 @@
-import json
 import logging
 import sys
 import warnings
 
 from localstack import config, constants
 
+from ..utils.collections import parse_key_value_pairs
 from .format import AddFormattedAttributes, DefaultFormatter
 
 # The log levels for modules are evaluated incrementally for logging granularity,
@@ -82,7 +82,7 @@ def setup_logging_from_config():
     raw_logging_override = config.LOGGING_OVERRIDE
     if raw_logging_override:
         try:
-            logging_overrides = json.loads(raw_logging_override)
+            logging_overrides = parse_key_value_pairs(raw_logging_override)
             for logger, level_name in logging_overrides.items():
                 level = getattr(logging, level_name, None)
                 if not level:

--- a/localstack/logging/setup.py
+++ b/localstack/logging/setup.py
@@ -26,6 +26,7 @@ default_log_levels = {
     "localstack.aws.accounts": logging.INFO,
     "localstack.aws.protocol.serializer": logging.INFO,
     "localstack.aws.serving.wsgi": logging.WARNING,
+    "localstack.dns": logging.INFO,
     "localstack.request": logging.INFO,
     "localstack.request.internal": logging.WARNING,
     "localstack.state.inspect": logging.INFO,

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -533,3 +533,18 @@ def is_comma_delimited_list(string: str, item_regex: Optional[str] = None) -> bo
     if pattern.match(string) is None:
         return False
     return True
+
+
+def parse_key_value_pairs(raw_text: str) -> dict:
+    result = {}
+    for pair in raw_text.split(","):
+        items = pair.split("=", maxsplit=2)
+        if len(items) != 2:
+            raise ValueError(f"invalid key/value pair: '{pair}'")
+        raw_key, raw_value = items[0].strip(), items[1].strip()
+        if not raw_key:
+            raise ValueError(f"missing key: '{pair}'")
+        if not raw_value:
+            raise ValueError(f"missing value: '{pair}'")
+        result[raw_key] = raw_value
+    return result

--- a/localstack/utils/collections.py
+++ b/localstack/utils/collections.py
@@ -536,9 +536,15 @@ def is_comma_delimited_list(string: str, item_regex: Optional[str] = None) -> bo
 
 
 def parse_key_value_pairs(raw_text: str) -> dict:
+    """
+    Parse a series of key-value pairs, in an environment variable format into a dictionary
+
+    >>> input = "a=b,c=d"
+    >>> assert parse_key_value_pairs(input) == {"a": "b", "c": "d"}
+    """
     result = {}
     for pair in raw_text.split(","):
-        items = pair.split("=", maxsplit=2)
+        items = pair.split("=")
         if len(items) != 2:
             raise ValueError(f"invalid key/value pair: '{pair}'")
         raw_key, raw_value = items[0].strip(), items[1].strip()

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -9,6 +9,7 @@ from localstack.utils.collections import (
     ImmutableList,
     convert_to_typed_dict,
     is_comma_delimited_list,
+    parse_key_value_pairs,
     select_from_typed_dict,
 )
 
@@ -193,3 +194,28 @@ def test_is_comma_limited_list():
     assert not is_comma_delimited_list("foo, bar baz")
     assert not is_comma_delimited_list("foo,")
     assert not is_comma_delimited_list("")
+
+
+@pytest.mark.parametrize(
+    "input_text,expected",
+    [
+        ("a=b", {"a": "b"}),
+        ("a=b,c=d", {"a": "b", "c": "d"}),
+    ],
+)
+def test_parse_key_value_pairs(input_text, expected):
+    assert parse_key_value_pairs(input_text) == expected
+
+
+@pytest.mark.parametrize(
+    "input_text,message",
+    [
+        ("a=b,", "invalid key/value pair: ''"),
+        ("a=b,c=", "missing value: 'c='"),
+    ],
+)
+def test_parse_key_value_pairs_error_messages(input_text, message):
+    with pytest.raises(ValueError) as exc_info:
+        parse_key_value_pairs(input_text)
+
+    assert str(exc_info.value) == message


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
Building on https://github.com/localstack/localstack/pull/10808, we want to enable debug logging for the DNS server.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Set default DNS logging level to INFO in debug mode, so DEBUG=1 does not enable this debug logging
* Add debug logging for DNS which can be enabled with the configuration LOGGING_OVERRIDE=localstack.dns=DEBUG

Requires https://github.com/localstack/localstack/pull/10808
<!-- Optional section: How to test these changes? -->
<!--
## Testing

-->

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
