### PR TITLE
CFn: Improve stack set support

### DIFF
--- a/localstack-core/localstack/services/cloudformation/engine/entities.py
+++ b/localstack-core/localstack/services/cloudformation/engine/entities.py
@@ -33,6 +33,14 @@ class StackInstance:
         # reference to the deployed stack belonging to this stack instance
         self.stack = None
 
+    @property
+    def account(self) -> str:
+        return self.metadata["Account"]
+
+    @property
+    def region(self) -> str:
+        return self.metadata["Region"]
+
 
 class StackSet:
     """A stack set contains multiple stack instances."""
@@ -82,7 +90,7 @@ class StackSet:
         }
         result = {
             "Version": "2010-09-09",
-            "ResourceTypes": ["AWS::S3::Bucket", "AWS::S3::Bucket"],
+            "ResourceTypes": ["AWS::SNS::Topic"],
             "Parameters": list(
                 extract_stack_parameter_declarations({"Parameters": parameters}).values()
             ),

--- a/localstack-core/localstack/services/cloudformation/engine/entities.py
+++ b/localstack-core/localstack/services/cloudformation/engine/entities.py
@@ -1,10 +1,17 @@
 import logging
 from typing import Optional, TypedDict
 
-from localstack.aws.api.cloudformation import Capability, ChangeSetType, Parameter
+from localstack.aws.api.cloudformation import (
+    Capability,
+    ChangeSetType,
+    CreateStackSetInput,
+    GetTemplateSummaryOutput,
+    Parameter,
+)
 from localstack.services.cloudformation.engine.parameters import (
     StackParameter,
     convert_stack_parameters_to_list,
+    extract_stack_parameter_declarations,
     strip_parameter_type,
 )
 from localstack.utils.aws import arns
@@ -17,22 +24,6 @@ from localstack.utils.time import timestamp_millis
 LOG = logging.getLogger(__name__)
 
 
-class StackSet:
-    """A stack set contains multiple stack instances."""
-
-    # FIXME: confusing name. metadata is the complete incoming request object
-    def __init__(self, metadata: dict):
-        self.metadata = metadata
-        # list of stack instances
-        self.stack_instances = []
-        # maps operation ID to stack set operation details
-        self.operations = {}
-
-    @property
-    def stack_set_name(self):
-        return self.metadata.get("StackSetName")
-
-
 class StackInstance:
     """A stack instance belongs to a stack set and is specific to a region / account ID."""
 
@@ -41,6 +32,72 @@ class StackInstance:
         self.metadata = metadata
         # reference to the deployed stack belonging to this stack instance
         self.stack = None
+
+
+class StackSet:
+    """A stack set contains multiple stack instances."""
+
+    def __init__(self, request: CreateStackSetInput):
+        self.request = request
+        # list of stack instances
+        self.stack_instances: list[StackInstance] = []
+        # maps operation ID to stack set operation details
+        self.operations = {}
+
+    # compatibility with old API
+    @property
+    def metadata(self) -> CreateStackSetInput:
+        return self.request
+
+    @property
+    def stack_set_name(self):
+        return self.request.get("StackSetName")
+
+    @property
+    def template_url(self) -> str | None:
+        return self.request.get("TemplateURL")
+
+    @property
+    def template_body(self) -> str | None:
+        return self.request.get("TemplateBody")
+
+    def get_template(self):
+        if body := self.template_body:
+            return body
+
+        raise NotImplementedError("template URL")
+
+    def get_template_summary(self) -> GetTemplateSummaryOutput:
+        # id_summaries = defaultdict(list)
+        # for resource_id, resource in stack.template_resources.items():
+        #     res_type = resource["Type"]
+        #     id_summaries[res_type].append(resource_id)
+
+        # hack to use this helper function
+        parameters = {
+            every["ParameterKey"]: {
+                "Type": "String",
+            }
+            for every in self.metadata["Parameters"]
+        }
+        result = {
+            "Version": "2010-09-09",
+            "ResourceTypes": ["AWS::S3::Bucket", "AWS::S3::Bucket"],
+            "Parameters": list(
+                extract_stack_parameter_declarations({"Parameters": parameters}).values()
+            ),
+        }
+        # result["ResourceIdentifierSummaries"] = [
+        #     {"ResourceType": key, "LogicalResourceIds": values}
+        #     for key, values in id_summaries.items()
+        # ]
+        return result
+
+    def get_instance(self, account: str, region: str) -> StackInstance | None:
+        for instance in self.stack_instances:
+            if instance.metadata["Account"] == account and instance.metadata["Region"] == region:
+                return instance
+        return None
 
 
 class StackMetadata(TypedDict):

--- a/localstack-core/localstack/services/cloudformation/engine/parameters.py
+++ b/localstack-core/localstack/services/cloudformation/engine/parameters.py
@@ -26,7 +26,7 @@ from localstack.aws.connect import connect_to
 
 def extract_stack_parameter_declarations(template: dict) -> dict[str, ParameterDeclaration]:
     """
-    Extract and build a dict of stack parameter declarations from a CloudFormation stack templatef
+    Extract and build a dict of stack parameter declarations from a CloudFormation stack template
 
     :param template: the parsed CloudFormation stack template
     :return: a dictionary of declared parameters, mapping logical IDs to the corresponding parameter declaration

--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -1231,7 +1231,7 @@ class CloudformationProvider(CloudformationApi):
                     sset_meta, ["TemplateURL"]
                 )
                 kwargs["Parameters"] = merge_parameters(
-                    sset_meta["Parameters"], request.get("ParameterOverrides", [])
+                    sset_meta.get("Parameters", []), request.get("ParameterOverrides", [])
                 )
                 # allow overrides from the request
                 stack_name = f"sset-{set_name}-{account}"

--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -110,6 +110,7 @@ from localstack.services.cloudformation.stores import (
     find_change_set,
     find_stack,
     find_stack_by_id,
+    find_stack_set,
     get_cloudformation_store,
 )
 from localstack.state import StateVisitor
@@ -530,6 +531,14 @@ class CloudformationProvider(CloudformationApi):
         request: GetTemplateSummaryInput,
     ) -> GetTemplateSummaryOutput:
         stack_name = request.get("StackName")
+        stack_set_name = request.get("StackSetName")
+
+        if stack_set_name:
+            stack_set = find_stack_set(context.account_id, context.region, stack_set_name)
+            if not stack_set:
+                # TODO: different error?
+                return stack_not_found_error(stack_set_name)
+            return stack_set.get_template_summary()
 
         if stack_name:
             stack = find_stack(context.account_id, context.region, stack_name)

--- a/localstack-core/localstack/services/cloudformation/provider.py
+++ b/localstack-core/localstack/services/cloudformation/provider.py
@@ -333,7 +333,7 @@ class CloudformationProvider(CloudformationApi):
         if not stack:
             return not_found_error(f'Unable to update non-existing stack "{stack_name}"')
 
-        api_utils.prepare_template_body(request)
+        api_utils.prepare_template_body(request, stack)
         template = template_preparer.parse_template(request["TemplateBody"])
 
         if (

--- a/localstack-core/localstack/services/cloudformation/stores.py
+++ b/localstack-core/localstack/services/cloudformation/stores.py
@@ -61,6 +61,14 @@ def find_stack(account_id: str, region_name: str, stack_name: str) -> Stack | No
     )[0]
 
 
+def find_stack_set(account_id: str, region_name: str, stack_set_name: str) -> StackSet | None:
+    state = get_cloudformation_store(account_id, region_name)
+    for name, stack_set in state.stack_sets.items():
+        # TODO: stack set id?
+        if stack_set_name in [name, stack_set.stack_set_name]:
+            return stack_set
+
+
 def find_stack_by_id(account_id: str, region_name: str, stack_id: str) -> Stack | None:
     """
     Find the stack by id.

--- a/localstack-core/localstack/utils/collections.py
+++ b/localstack-core/localstack/utils/collections.py
@@ -26,6 +26,7 @@ from typing import (
 )
 
 import cachetools
+import jsonpath_ng
 
 LOG = logging.getLogger(__name__)
 
@@ -533,3 +534,15 @@ def is_comma_delimited_list(string: str, item_regex: Optional[str] = None) -> bo
     if pattern.match(string) is None:
         return False
     return True
+
+
+def convert_in_place_at_jsonpath(params: dict, jsonpath: str, conversion_fn: Callable[[Any], Any]):
+    """
+    Invokes a conversion function on a dictionary nested entry at a specific jsonpath with `conversion_fn`
+    """
+    jp = jsonpath_ng.parse(jsonpath)
+    old_value = jp.find(params)[0].value
+    if not old_value:
+        return
+    new_value = conversion_fn(old_value)
+    jp.update(params, new_value)

--- a/tests/aws/services/cloudformation/resources/test_stack_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_stack_sets.snapshot.json
@@ -1,9 +1,30 @@
 {
   "tests/aws/services/cloudformation/resources/test_stack_sets.py::test_create_stack_set_with_stack_instances": {
-    "recorded-date": "24-05-2023, 15:32:47",
+    "recorded-date": "01-05-2024, 16:29:26",
     "recorded-content": {
       "create_stack_set": {
         "StackSetId": "<stack-set-id:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "template-summary": {
+        "Parameters": [
+          {
+            "NoEcho": false,
+            "ParameterConstraints": {
+              "AllowedValues": []
+            },
+            "ParameterKey": "BucketName",
+            "ParameterType": "String"
+          }
+        ],
+        "ResourceTypes": [
+          "AWS::S3::Bucket",
+          "AWS::S3::Bucket"
+        ],
+        "Version": "2010-09-09",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudformation/resources/test_stack_sets.snapshot.json
+++ b/tests/aws/services/cloudformation/resources/test_stack_sets.snapshot.json
@@ -1,6 +1,6 @@
 {
   "tests/aws/services/cloudformation/resources/test_stack_sets.py::test_create_stack_set_with_stack_instances": {
-    "recorded-date": "01-05-2024, 16:29:26",
+    "recorded-date": "03-05-2024, 16:06:54",
     "recorded-content": {
       "create_stack_set": {
         "StackSetId": "<stack-set-id:1>",
@@ -12,17 +12,17 @@
       "template-summary": {
         "Parameters": [
           {
+            "DefaultValue": "sns-topic-simple",
             "NoEcho": false,
             "ParameterConstraints": {
               "AllowedValues": []
             },
-            "ParameterKey": "BucketName",
+            "ParameterKey": "TopicName",
             "ParameterType": "String"
           }
         ],
         "ResourceTypes": [
-          "AWS::S3::Bucket",
-          "AWS::S3::Bucket"
+          "AWS::SNS::Topic"
         ],
         "Version": "2010-09-09",
         "ResponseMetadata": {
@@ -32,6 +32,13 @@
       },
       "create_stack_instances": {
         "OperationId": "<uuid:1>",
+        "ResponseMetadata": {
+          "HTTPHeaders": {},
+          "HTTPStatusCode": 200
+        }
+      },
+      "recreate_stack_instances": {
+        "OperationId": "<uuid:2>",
         "ResponseMetadata": {
           "HTTPHeaders": {},
           "HTTPStatusCode": 200

--- a/tests/aws/services/cloudformation/resources/test_stack_sets.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_stack_sets.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/cloudformation/resources/test_stack_sets.py::test_create_stack_set_with_stack_instances": {
-    "last_validated_date": "2023-05-24T13:32:47+00:00"
+    "last_validated_date": "2024-05-01T16:29:26+00:00"
   }
 }

--- a/tests/aws/services/cloudformation/resources/test_stack_sets.validation.json
+++ b/tests/aws/services/cloudformation/resources/test_stack_sets.validation.json
@@ -1,5 +1,5 @@
 {
   "tests/aws/services/cloudformation/resources/test_stack_sets.py::test_create_stack_set_with_stack_instances": {
-    "last_validated_date": "2024-05-01T16:29:26+00:00"
+    "last_validated_date": "2024-05-03T16:06:54+00:00"
   }
 }

--- a/tests/aws/templates/s3_cors_bucket.yaml
+++ b/tests/aws/templates/s3_cors_bucket.yaml
@@ -1,12 +1,7 @@
-Parameters:
-  BucketName:
-    Type: String
-
 Resources:
   LocalBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Ref BucketName
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:

--- a/tests/aws/templates/s3_cors_bucket.yaml
+++ b/tests/aws/templates/s3_cors_bucket.yaml
@@ -1,7 +1,12 @@
+Parameters:
+  BucketName:
+    Type: String
+
 Resources:
   LocalBucket:
     Type: AWS::S3::Bucket
     Properties:
+      BucketName: !Ref BucketName
       CorsConfiguration:
         CorsRules:
           - AllowedHeaders:

--- a/tests/unit/utils/test_collections.py
+++ b/tests/unit/utils/test_collections.py
@@ -7,6 +7,7 @@ from localstack.utils.collections import (
     HashableList,
     ImmutableDict,
     ImmutableList,
+    convert_in_place_at_jsonpath,
     convert_to_typed_dict,
     is_comma_delimited_list,
     select_from_typed_dict,
@@ -193,3 +194,21 @@ def test_is_comma_limited_list():
     assert not is_comma_delimited_list("foo, bar baz")
     assert not is_comma_delimited_list("foo,")
     assert not is_comma_delimited_list("")
+
+
+@pytest.mark.parametrize(
+    "input,jsonpath,fn,expected",
+    [
+        # examples taken from ECS
+        ({"desiredCount": "1"}, "desiredCount", int, {"desiredCount": 1}),
+        (
+            {"serviceConnectConfiguration": {"services": [{"clientAliases": [{"port": "80"}]}]}},
+            "serviceConnectConfiguration.services[*].clientAliases[*].port",
+            int,
+            {"serviceConnectConfiguration": {"services": [{"clientAliases": [{"port": 80}]}]}},
+        ),
+    ],
+)
+def test_convert_in_place_at_jsonpath(input, jsonpath, fn, expected):
+    convert_in_place_at_jsonpath(input, jsonpath, fn)
+    assert input == expected


### PR DESCRIPTION
<!-- Please refer to the contribution guidelines before raising a PR: https://github.com/localstack/localstack/blob/master/docs/CONTRIBUTING.md -->

<!-- Why am I raising this PR? Add context such as related issues, PRs, or documentation. -->
## Motivation
I updated our [copilot-local repo](https://github.com/localstack/copilot-cli-local) to the latest upstream commit, and it did not work against LocalStack any more. I am not 100% sure the current commit works either.

The initial failure reason was our StackSet support in CloudFormation.

<!-- What changes does this PR make? How does LocalStack behave differently now? -->
## Changes
* Update `get_template_body` to allow use of the previous stack (UsePreviousStack)
* Expand on the `StackSet` entity mostly allowing access to the template body for use by `StackInstance`s
* Look up stack sets when retrieving template summaries
* Merge `StackInstance` parameter overrides with `StackSet` parameter definitions
* Introduce `convert_in_place_at_jsonpath` for deep nested structure in place type conversion
* Expand on `test_create_stack_set_with_stack_instances` test to support parameter overrides

<!-- Optional section: How to test these changes? -->

## Testing
I have been testing with [my fork of copilot-local](https://github.com/simonrw/copilot-cli-local/commit/f6d10578b6ebe6337fc84a8b5947d05c35e9776f) which has a few changes to the LocalStack fork of copilot:

* the `localstack` branch has been rebased onto the latest tagged release (v1.33.3 at the time of writing)
* the manifest parsing has been improved to correctly handle escaped newlines, which cause invalid yaml parsing

As of 2024-06-07 I had not yet completed the work required to fix copilot-local. I think I was close, but not there yet.

<!-- Optional section: What's left to do before it can be merged? -->
<!--
## TODO

What's left to do:

- [ ] ...
- [ ] ...
-->
